### PR TITLE
notice for nt-style headers on refseq DB

### DIFF
--- a/docs/benchmarking/rename_nt/README.md
+++ b/docs/benchmarking/rename_nt/README.md
@@ -21,12 +21,14 @@ Then use the rename_nt.py to add the taxids in sequence headers. You might need 
 Sequence headers should look like `>1234|sequence_description`, where 1234 is the taxid.
 
 
-## Steps to rename the RefSeq database
+## Steps to rename the RefSeq database to index with KMA
 
-A less modular script than `rename_nt.py` (which operates on individual fasta files), this will download all the NCBI `"reference genome"` level accessions (currently 20,858 fna, 31GB), and add the `taxid` to the header ( i.e. `>accession_abc` to `>1234|accession_abc`).
+`rename_refseq.sh` is a less modular script than `rename_nt.py` (which operates on individual fasta files). `rename_refseq.sh` will download all the NCBI `"reference genome"` level accessions (currently 20,858 fna, 31GB), and add the `taxid` to the header as above ( i.e. `>accession_abc` to `>1234|accession_abc`). 
+
+**Note:** this script will change the headers in the downloaded `RefSeq` data to `nt`-style (i.e. to match `rename_nt.py` output, as above). This is particularly important for running `CCMetagen.py`: if you have used `rename_refseq.sh`, add `-r nt` to your `CCMetagen.py` command, or simply leave out the `-r` flag altogether (this works because `-r nt` is the default).  See the corresponding [issue #73](https://github.com/vrmarcelino/CCMetagen/issues/73#issuecomment-2808967200) for more information.
 
 Given a `$destination_folder` for the downloads (recommend you choose a new, empty folder!) and a number of `$nthreads`, should be able to call:
 ```
 rename_refseq.sh  $destination_folder  $nthreads
 ```
-The script took about 4 hours with an institutional connection and 20 cores.  
+The script took about 4 hours with an institutional/university connection and 20 cores.  

--- a/docs/benchmarking/rename_nt/rename_refseq.sh
+++ b/docs/benchmarking/rename_nt/rename_refseq.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/bash
 
-## ================================================================================================ ##   handibles.mar.25
-##   A less modular script than rename_nt.py (which operates on individual fasta files), this will  ##
-##   download all the NCBI `"reference genome"` level accessions (currently 20,858 fna, 31GB), and  ##
-##   add the `taxid` to the header ( i.e. `>accession_abc` to `>1234|accession_abc`)                ##
-##                                                                                                  ##
-##   > rename_refseq.sh  $destination_folder  $nthreads                                             ##
-## ------------------------------------------------------------------------------------------------ ##
+## ================================================================================================================================= ##  handibles.may.25
+##   rename_refseq.sh is a less modular script than rename_nt.py (which operates on individual fasta files). rename_refseq.sh will   ##
+##   download all the NCBI "reference genome" level accessions (currently 20,858 fna, 31GB), and add the taxid to the header as      ##
+##   per rename_nt.py ( i.e. change >accession_abc to >1234|accession_abc). NOTE: this will give nt-style headers to RefSeq data.    ##
+##   For CCMetagen.py add the '-r nt' command, or omit the -r flag altogether ('-r nt' is the default).                              ##
+##                                                                                                                                   ##
+##   > rename_refseq.sh  $destination_folder  $nthreads                                                                              ##
+## --------------------------------------------------------------------------------------------------------------------------------- ##
 
 workdir=$1
 threeds=$2
@@ -15,14 +16,14 @@ if [ -z $threeds ] ; then threeds=20 ; fi
 # the dir wherin the RefSeq is stowed
 mkdir -p $workdir
 
-echo " + 1 +   recommended to dl some NCBI RefSeq genomes - 30m  ---------------"
+echo " +-1-+   recommended to dl some NCBI RefSeq genomes - 30m  ---------------"
 wget https://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt -O $workdir/assembly_summary.txt   > $workdir/wgetlog1.temp 2>&1  
 grep "reference genome" $workdir/assembly_summary.txt >> $workdir/assembly_summary_ref.txt                                # 20,858 references
 cut -f20 $workdir/assembly_summary_ref.txt | parallel -j $threeds "wget -r -np -nH --cut-dirs=5 {}/{/}_genomic.fna.gz -O $workdir/{/}_genomic.fna.gz" >> $workdir/wgetlog1.temp 2>&1  
 # 26GB, 29min, Mar.2025 - 20,860 fna.gz
 
 
-echo " + 2 +   get RefSeq ("_") accession-taxid listings - 10m?  ---------------"
+echo " + 2 +   get RefSeq ( _ ) accession-taxid listings - 10m?  ---------------"
 wget http://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz -O $workdir/nucl_gb.accession2taxid.gz >> $workdir/wgetlog2.temp 2>&1           # 2.3/13GB - non TranscrShotAss / WGS
 wget https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz -O $workdir/nucl_wgs.accession2taxid.gz >> $workdir/wgetlog3.temp 2>&1   # 5.0/33GB - TranscrShotAss / WGS
 zgrep "_" $workdir/nucl_*.accession2taxid.gz | cut -f 2-3 > $workdir/accession_taxid_nucl-rs.map                          # 124,253,447 entries ; says 3m but thats not true
@@ -36,15 +37,14 @@ export -f accession_filename
 parallel --keep-order -j $threeds accession_filename {} ::: ${workdir}/*genomic.fna.gz > $workdir/accession_fqpath-rs.map  # 3m, 1,074,620 entries, 20857 fna.gz 
 
 
-echo " + 4 +   sort & join two lists by accession - 3m  ----(ignore 9606 error!)"
+echo " + 4 +   sort & join two lists by accession - 3m  ----(ignore 9606 error)-"
 time join -j 1 -e XXXcatastrophotronXXXX -o 1.2,2.2 <( sort $workdir/accession_taxid_nucl-rs.map ) <( sort $workdir/accession_fqpath-rs.map ) | tr " " "\t" | sort -u > $workdir/taxid_fqpath.map
-## 
-# join: /dev/fd/63:307894: is not sorted: NM_001000.4     9606
-# join: input is not in sorted order
 
 
 echo " + 5 +   re-stamp headers - 30m  -----------------------------------------"
 cat $workdir/taxid_fqpath.map | \
-  parallel --colsep "\t" -j $threeds "gzip -dc {2} | sed -E \"s/>/>{1}\|/g\" > {=2 s/(.*).fna.gz/\${1}_taxID2.fna/=} "  >> $workdir/stamplog.temp 2>&1
+parallel --colsep "\t" -j $threeds "gzip -dc {2} | sed -E \"s/>/>{1}\|/g\" > {=2 s/(.*).fna.gz/\${1}_taxID2.fna/=} "  >> $workdir/stamplog.temp 2>&1
+
 
 parallel -j $threeds gzip {} ::: $workdir/*genomic_taxID2.fna && rm $workdir/*genomic.fna.gz  # 20min
+echo " +-6-+   done. NOTE :: use the '-r nt' flag with CCMetagen.py  ___________"

--- a/docs/benchmarking/rename_nt/rename_refseq.sh
+++ b/docs/benchmarking/rename_nt/rename_refseq.sh
@@ -16,14 +16,15 @@ if [ -z $threeds ] ; then threeds=20 ; fi
 mkdir -p $workdir
 
 echo " + 1 +   recommended to dl some NCBI RefSeq genomes - 30m  ---------------"
-wget https://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt -O $workdir/assembly_summary.txt   > $workdir/wgetlog.temp 2>&1  
+wget https://ftp.ncbi.nlm.nih.gov/genomes/refseq/bacteria/assembly_summary.txt -O $workdir/assembly_summary.txt   > $workdir/wgetlog1.temp 2>&1  
 grep "reference genome" $workdir/assembly_summary.txt >> $workdir/assembly_summary_ref.txt                                # 20,858 references
-cut -f20 $workdir/assembly_summary_ref.txt | parallel -j $threeds "wget -r -np -nH --cut-dirs=5 {}/{/}_genomic.fna.gz -O $workdir/{/}_genomic.fna.gz" >> $workdir/wgetlog.temp 2>&1  
+cut -f20 $workdir/assembly_summary_ref.txt | parallel -j $threeds "wget -r -np -nH --cut-dirs=5 {}/{/}_genomic.fna.gz -O $workdir/{/}_genomic.fna.gz" >> $workdir/wgetlog1.temp 2>&1  
 # 26GB, 29min, Mar.2025 - 20,860 fna.gz
 
+
 echo " + 2 +   get RefSeq ("_") accession-taxid listings - 10m?  ---------------"
-wget ftp://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz -O $workdir/nucl_gb.accession2taxid.gz >> $workdir/wgetlog.temp 2>&1           # 2.3/13GB - non TranscrShotAss / WGS
-wget https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz -O $workdir/nucl_wgs.accession2taxid.gz >> $workdir/wgetlog.temp 2>&1   # 5.0/33GB - TranscrShotAss / WGS
+wget http://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz -O $workdir/nucl_gb.accession2taxid.gz >> $workdir/wgetlog2.temp 2>&1           # 2.3/13GB - non TranscrShotAss / WGS
+wget https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz -O $workdir/nucl_wgs.accession2taxid.gz >> $workdir/wgetlog3.temp 2>&1   # 5.0/33GB - TranscrShotAss / WGS
 zgrep "_" $workdir/nucl_*.accession2taxid.gz | cut -f 2-3 > $workdir/accession_taxid_nucl-rs.map                          # 124,253,447 entries ; says 3m but thats not true
 
 
@@ -32,18 +33,17 @@ accession_filename () {
   zcat $1 | awk -v filen=$1 '/^>/ {print substr($1, 2), "\t", filen}'
 }
 export -f accession_filename
-parallel --keep-order -j $threeds accession_filename {} ::: ${workdir}/*genomic.fna.gz > $workdir/accession_fqpath-rs.map
-# 3m, 1,074,620 entries, 20857 fna.gz 
+parallel --keep-order -j $threeds accession_filename {} ::: ${workdir}/*genomic.fna.gz > $workdir/accession_fqpath-rs.map  # 3m, 1,074,620 entries, 20857 fna.gz 
 
 
-echo " + 4 +   sort & join two lists by accession - 1m  ----(ignore 9606 error!)"
-join -j 1 -e XXXcatastrophotronXXXX -o 1.2,2.2 <( sort $workdir/accession_taxid_nucl-rs.map ) <( sort $workdir/accession_fqpath-rs.map ) | tr " " "\t" > $workdir/taxid_fqpath.map
+echo " + 4 +   sort & join two lists by accession - 3m  ----(ignore 9606 error!)"
+time join -j 1 -e XXXcatastrophotronXXXX -o 1.2,2.2 <( sort $workdir/accession_taxid_nucl-rs.map ) <( sort $workdir/accession_fqpath-rs.map ) | tr " " "\t" | sort -u > $workdir/taxid_fqpath.map
 ## 
 # join: /dev/fd/63:307894: is not sorted: NM_001000.4     9606
 # join: input is not in sorted order
 
 
-echo " + 5 +   re-stamp headers - ~200m  ----------------------------------------"
+echo " + 5 +   re-stamp headers - 30m  -----------------------------------------"
 cat $workdir/taxid_fqpath.map | \
   parallel --colsep "\t" -j $threeds "gzip -dc {2} | sed -E \"s/>/>{1}\|/g\" > {=2 s/(.*).fna.gz/\${1}_taxID2.fna/=} "  >> $workdir/stamplog.temp 2>&1
 


### PR DESCRIPTION
add flag / note about adding nt-style headers to RefSeq data to rename_refseq.sh / readme, respectively. Entreat users to use -r nt, or even better omit the flag altogether as per #73